### PR TITLE
enable params.format to configure xml query result

### DIFF
--- a/lib/yql.js
+++ b/lib/yql.js
@@ -28,7 +28,7 @@ YQL.exec = function(yqlQuery, callback, params, httpOpts) {
 
     // Required YQL paramaters
     params.env    = params.env || 'http://datatables.org/alltables.env';
-    params.format = 'json';
+    params.format = params.format || 'json';
     params.q      = yqlQuery;
 
     // Construct the querystring


### PR DESCRIPTION
You can add format:'xml' in params to request xml query result
