### PR TITLE
Allowing to setup a timeout for the yql request

### DIFF
--- a/lib/yql.js
+++ b/lib/yql.js
@@ -41,15 +41,29 @@ YQL.exec = function(yqlQuery, callback, params, httpOpts) {
     // Delete httpOpts.ssl as we already reassigned it and don't want stray HTTP headers
     delete httpOpts.ssl;
 
+    var timeout = httpOpts.timeout || null;
+    if (timeout) {
+        delete httpOpts.timeout;
+    }
+
+    var options = {
+        headers: httpOpts,
+        json:    true,
+        method:  'GET',
+        url:     url.parse((ssl == true ? 'https': 'http') + '://' + host + path + '?' + queryString)
+    };
+
+    // Add timeout (in milliseconds) if present in the options
+    if (timeout) {
+        options.timeout = parseInt(timeout);
+    }
+
     // Execute the YQL request and fire the callback
-    request({
-            headers: httpOpts,
-            json:    true,
-            method:  'GET',
-            url:     url.parse((ssl == true ? 'https': 'http') + '://' + host + path + '?' + queryString)
-        }, function(error, response, body) {
+    request(options, function(error, response, body) {
             if (!error) {
                 if (callback) callback((body));
+            } else if (error && error.code == 'ETIMEDOUT') {
+                if (callback) callback(error.code);
             }
             else {
                 throw 'Something went wrong with an HTTP request';


### PR DESCRIPTION
Sometimes yql servers will timeout after 30 or 60 seconds.

With this patch we can control that per request.
