### PR TITLE
splitting out building of the url object into it's own function

### DIFF
--- a/examples/stream.js
+++ b/examples/stream.js
@@ -1,0 +1,6 @@
+var yql = require('../lib/yql'),
+    request = require('request');
+
+var url = yql.buildUrl("SELECT * FROM weather.forecast WHERE (location = 93063)");
+
+request.get(url.href).pipe(process.stdout);

--- a/lib/yql.js
+++ b/lib/yql.js
@@ -12,21 +12,13 @@ var request = require('request'),
     url     = require('url'),
     YQL     = exports;
 
-YQL.exec = function(yqlQuery, callback, params, httpOpts) {
-
-    if (!yqlQuery) { 
-        console.error("Error: Missing YQL statement");
-    }
-
-    // Default the optional args
-    callback = (callback !== undefined ? callback : false);
+YQL.buildUrl = function(yqlQuery, params, ssl) {
     params   = (params !== undefined ? params : {});
-    httpOpts = (httpOpts !== undefined ? httpOpts : { ssl: false });
+    ssl      = ssl || false;
     
     var host = 'query.yahooapis.com',
         path = '/v1/public/yql',
-        queryString = '',
-        ssl = httpOpts.ssl;
+        queryString = '';
 
     // Required YQL paramaters
     params.env    = (params.env !== undefined ? params.env : 'http://datatables.org/alltables.env');
@@ -37,6 +29,21 @@ YQL.exec = function(yqlQuery, callback, params, httpOpts) {
     for (var key in params) {
         queryString += key + '=' + encodeURIComponent(params[key]) + '&';
     }
+
+    return url.parse((ssl == true ? 'https': 'http') + '://' + host + path + '?' + queryString);
+};
+
+YQL.exec = function(yqlQuery, callback, params, httpOpts) {
+
+    if (!yqlQuery) {
+        console.error("Error: Missing YQL statement");
+    }
+
+    // Default the optional args
+    callback = (callback !== undefined ? callback : false);
+    httpOpts = (httpOpts !== undefined ? httpOpts : { ssl: false });
+
+    var ssl = httpOpts.ssl;
 
     // Delete httpOpts.ssl as we already reassigned it and don't want stray HTTP headers
     delete httpOpts.ssl;
@@ -50,7 +57,7 @@ YQL.exec = function(yqlQuery, callback, params, httpOpts) {
         headers: httpOpts,
         json:    true,
         method:  'GET',
-        url:     url.parse((ssl == true ? 'https': 'http') + '://' + host + path + '?' + queryString)
+        url: YQL.buildUrl(yqlQuery, params, ssl)
     };
 
     // Add timeout (in milliseconds) if present in the options

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 , "version"      : "0.4.8"
 , "engines"      : { ">=npm":"1.1.0-3", "node":">=v0.6.9" }
 , "maintainers"  : [ { "name": "Derek Gathright", "email": "drg@yahoo-inc.com" } ]
-, "scripts"      : { "test": "test.js" }
+, "scripts"      : { "test": "node tests/main.js" }
 , "main"         : "./lib/yql"
 , "directories"  : { "lib" : "./lib/" }
 , "description"  : "A YQL (Yahoo Query Language) client"

--- a/tests/main.js
+++ b/tests/main.js
@@ -8,7 +8,7 @@ All rights reserved.
 */
 
 var assert = require('assert'),
-    yql    = require('yql');
+    yql    = require('../lib/yql');
 
 // Example #1 - Param binding
 new yql.exec("SELECT * FROM weather.forecast WHERE (location = @zip)", function(response) {
@@ -54,6 +54,17 @@ new yql.exec("SELECT * FROM html", function(response) {
     }
     catch (e) { return fail(testID, e); }
 });
+
+// Example #5 - buildUrl
+(function() {
+    var testID = "5",
+        url = yql.buildUrl("SELECT * FROM weather.forecast WHERE (location = 93063)");
+    try {
+        assert.equal(url.href, 'http://query.yahooapis.com/v1/public/yql?env=http%3A%2F%2Fdatatables.org%2Falltables.env&format=json&q=SELECT%20*%20FROM%20weather.forecast%20WHERE%20(location%20%3D%2093063)&');
+        pass(testID);
+    }
+    catch (e) { return fail(testID, e); }
+}());
 
 
 function pass(testID) {


### PR DESCRIPTION
This allows you to grab the url among other things without making the actual request. This is super useful because you can easily make the request yourself and stream it. For example, 

``` javascript
var url = yql.buildUrl("SELECT * FROM weather.forecast WHERE (location = 93063)");
request.get(url.href).pipe(process.stdout);
```

Maybe `buildUrl` isn't a great name because it's actually returning an object. Thoughts and/or suggestions?
